### PR TITLE
fix: reorder tabs so search stays on the right

### DIFF
--- a/Polymarket/Views/HomeView.swift
+++ b/Polymarket/Views/HomeView.swift
@@ -22,6 +22,7 @@ struct HomeView: View {
     @State private var isConnectWalletPresented = false
     @State private var selectedPositionId: String?
     @State private var isRefreshing: Bool = false
+    @State private var selectedTab: Int = 0
     
     var selectedPosition: PolymarketDataService.Position? {
         dataService.positions?.first { $0.conditionId == selectedPositionId }
@@ -29,27 +30,27 @@ struct HomeView: View {
     
     var body: some View {
 #if os(iOS)
-        TabView {
-            Tab("Portfolio", systemImage: "chart.pie") {
+        TabView(selection: $selectedTab) {
+            Tab("Portfolio", systemImage: "chart.pie", value: 0) {
                 NavigationStack {
                     PortfolioTabView(wallet: wallet)
                 }
             }
-            
-            Tab(role: .search) {
-                NavigationStack {
-                    SearchMarketView()
-                }
-            }
-            
-            Tab("Watchlist", systemImage: "bookmark") {
+
+            Tab("Watchlist", systemImage: "bookmark", value: 1) {
                 NavigationStack {
                     WatchlistTabView()
                 }
             }
-            
-            Tab("Discover", systemImage: "sparkles") {
+
+            Tab("Discover", systemImage: "sparkles", value: 2) {
                 DiscoveryView()
+            }
+
+            Tab("Search", systemImage: "magnifyingglass", value: 3, role: .search) {
+                NavigationStack {
+                    SearchMarketView()
+                }
             }
         }
         .environment(\.symbolVariants, .none)

--- a/Polymarket/Views/HomeView.swift
+++ b/Polymarket/Views/HomeView.swift
@@ -22,32 +22,31 @@ struct HomeView: View {
     @State private var isConnectWalletPresented = false
     @State private var selectedPositionId: String?
     @State private var isRefreshing: Bool = false
-    @State private var selectedTab: Int = 0
-    
+
     var selectedPosition: PolymarketDataService.Position? {
         dataService.positions?.first { $0.conditionId == selectedPositionId }
     }
-    
+
     var body: some View {
 #if os(iOS)
-        TabView(selection: $selectedTab) {
-            Tab("Portfolio", systemImage: "chart.pie", value: 0) {
+        TabView {
+            Tab("Portfolio", systemImage: "chart.pie") {
                 NavigationStack {
                     PortfolioTabView(wallet: wallet)
                 }
             }
 
-            Tab("Watchlist", systemImage: "bookmark", value: 1) {
+            Tab("Watchlist", systemImage: "bookmark") {
                 NavigationStack {
                     WatchlistTabView()
                 }
             }
 
-            Tab("Discover", systemImage: "sparkles", value: 2) {
+            Tab("Discover", systemImage: "sparkles") {
                 DiscoveryView()
             }
 
-            Tab("Search", systemImage: "magnifyingglass", value: 3, role: .search) {
+            Tab(role: .search) {
                 NavigationStack {
                     SearchMarketView()
                 }


### PR DESCRIPTION
The search tab was second in the list. iOS only pins `Tab(role: .search)` to the trailing end of the tab bar when it is the *last* tab declared — any earlier position puts it in the middle.

## Change

Reorder: Portfolio → Watchlist → Discover → Search

One change, no new state, no selection binding. `Tab(role: .search)` stays exactly as it was.

## Before / After

| Before | After |
|--------|-------|
| Portfolio, *Search*, Watchlist, Discover | Portfolio, Watchlist, Discover, *Search* 🔍 |